### PR TITLE
Update exchange.json

### DIFF
--- a/server/database/banano/known-accounts/exchange.json
+++ b/server/database/banano/known-accounts/exchange.json
@@ -221,8 +221,8 @@
     },
     {
         "address": "ban_3r8txi61ppg5ekw6aa5gsdsk3cj6jpxe3towd4jmxswr8pckgiqs9muneey5",
-        "alias": "HitBTC/XGo",
-        "owner": "HitBTC/XGo"
+        "alias": "UnionChain - HitBTC/XGo",
+        "owner": "UnionChain[.]ai"
     },
     {
         "address": "ban_1usdc1u6y9ixwx6f66xiezsza5eqsriwhwqzaopuf9musmsgm5pfjfkr7bpu",


### PR DESCRIPTION
UnionChain is the owner of address used by HitBTC and XGo and wanted an update