### PR TITLE
external APIs changed to optional and frontend examples matching the environment

### DIFF
--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { environment } from '../../../environments/environment';
 
 @Component({
     selector: 'app-home',
@@ -34,7 +35,7 @@ import { Component } from '@angular/core';
 
                 <div class="section-body" style="margin-bottom: 12px">
                     <div class="mat-h2 link" style="margin-bottom: 0; word-break: break-all">
-                        https://api.spyglass.pw/banano/&#60;request-path&#62;
+                        {{ apiUrl }}
                     </div>
                 </div>
                 <div class="section-body">
@@ -77,7 +78,8 @@ import { Component } from '@angular/core';
 })
 export class HomeComponent {
     examplePost = `
-curl -X POST https://api.spyglass.pw/banano/v1/representatives
+curl -X POST ${environment.api}/v1/representatives
 -H 'Content-Type: application/json'
 -d '{"minimumWeight":"100000"}'`;
+    apiUrl = environment.api + '/<request-path>';
 }

--- a/server/src/services/api/price/exchange-rate.service.ts
+++ b/server/src/services/api/price/exchange-rate.service.ts
@@ -60,6 +60,7 @@ const getConversions = async () => {
 
 /** This is called to update the Exchange Rate Data in the AppCache.  Reads price data from https://exchangerate.host. */
 export const cacheExchangeRateData = async (): Promise<void> => {
+    if (typeof process.env.EXCHANGERATEHOST_API_KEY === 'undefined') return;
     try {
         const start = LOG_INFO('Refreshing Exchange Rate Data');
         await getSymbols();

--- a/server/src/services/api/price/price.service.ts
+++ b/server/src/services/api/price/price.service.ts
@@ -59,6 +59,7 @@ const getPrice = (): Promise<PriceDataDto> => {
 
 /** This is called to update the Price Data in the AppCache.  Reads price data from CoinMarketCap. */
 export const cachePriceData = async (): Promise<void> => {
+    if (typeof process.env.CMC_API_KEY === 'undefined') return;
     return new Promise((resolve) => {
         const start = LOG_INFO('Refreshing Price Data');
         getPrice()


### PR DESCRIPTION
Made the external apis (cmc and exchangerate) optional by returning early before the values that require those tokens are getting cached if the corresponding token evaluates to `undefined`.
the `/price` and `/price/exchange-rates` endpoints will return [501 Not Implemented](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501) with a message that explains why it does not work.

Additionally the frontend examples that display the api url on the homepage now change based on the api url defined in the environment.