### PR TITLE
Add Slip-a-Swole's payout address

### DIFF
--- a/server/database/banano/known-accounts/faucet.json
+++ b/server/database/banano/known-accounts/faucet.json
@@ -353,5 +353,10 @@
         "address": "ban_3iuhae1nq4e1k4r59h4h3p16x5m5c7czmuetm81xmkjeqensxyk3irocz9yy",
         "alias": "IamFaucet",
         "owner": "IamGabriel"
+    },
+    {
+        "address": "ban_3sasp5kddnz7n9gi56ijidc6yi6butjguwbg1cfgiyjqunhhotbgddh4zx1z",
+        "alias": "Slip-a-Swole",
+        "owner": "cmasta"
     }
 ]


### PR DESCRIPTION
Wallet to distribute rewards for Slip-a-Swole players.

It's not really a faucet, but it's in this category for now.